### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,34 @@ want them displayed, from left to right. You may use the bundled blocks in
 | click-handler | The procedure that is run when this block is clicked. The block must have its name field set. | `(lambda (event block) (block))`|
 | signal | SIGRTIMIN offset that this block will be listening on and refresh on. Can be triggered by sending a SIGRTMIN+signal to the guile process running gubar -- `pkill -SIGRTMIN+signal -f -n gubar.scm`  | `2` |
 
+#### Examples
+
+All keys are optional, so the most basic block with no text at all is
+`(gublock)`. Here's a block that the number of seconds it has been active:
+
+```scheme
+(gublock
+ #:interval 1 ; update each second
+ #:procedure
+ (let ((counter 0))
+   (lambda (block)
+     (set! counter (+ counter 1))
+     (set-block-full-text! block (number->string counter))
+     block)))
+```
+
+And here's a block that shows a random number every time you click it:
+
+```scheme
+(gublock
+ #:block (("full_text" . "Click me!")
+          ("name" . "randomizer"))
+ #:click-handler
+ (lambda (_ block)
+   (set-block-full-text! block (number->string (random 1000000)))
+   block))
+```
+
 ### Built-in Blocks
 
 | Block                | Declaration                                         | Info                                                                                                                     |

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ want them displayed, from left to right. You may use the bundled blocks in
 |-----|-------------|--------
 | block | Initial block represented as an assoc list. | `'(("full_text" . "foo"))` |
 | interval | Time in seconds in which this block updates | seconds or `'persistent` |
-| procedure | The main procedure that will be run after `interval`. Receives a <block> and returns a `<block>` record. | `(lambda (block) block)`|
+| procedure | The main procedure that will be run after `interval`. Receives a `<block>` and returns a `<block>` record. | `(lambda (block) block)`|
 | click-handler | The procedure that is run when this block is clicked. The block must have its name field set. | `(lambda (event block) (block))`|
 | signal | SIGRTIMIN offset that this block will be listening on and refresh on. Can be triggered by sending a SIGRTMIN+signal to the guile process running gubar -- `pkill -SIGRTMIN+signal -f -n gubar.scm`  | `2` |
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,11 @@ want them displayed, from left to right. You may use the bundled blocks in
 `gublocks` that exists in the `gubar gublock` module.
 
 ### `gublock`
-**Subject to change!!!**
+A `gublock` is the fundamental building block of `Gubar`.
+
+| :warning: **Subject to Change** |
+|---------------------------------|
+| The `gublock` interface is unstable and may change at any point |
 
 ```scheme
 (gublock 
@@ -68,6 +72,7 @@ want them displayed, from left to right. You may use the bundled blocks in
     #:click-handler [click-handler]
     #:signal [signal])
 ```
+The effects of the keys are as follows:
 
 | Key | Description | Example 
 |-----|-------------|--------


### PR DESCRIPTION
This MR adds some basic `gublock` examples, fixes missing backticks around `<block>` and also adds a bit of filler text.